### PR TITLE
Setting a `main` field that makes sense.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
             "url": "https://github.com/dylang/grunt-attention/blob/master/LICENSE-MIT"
         }
     ],
-    "main": "Gruntfile.js",
+    "main": "lib/generate-message.js",
     "engines": {
         "node": ">= 0.8.0"
     },


### PR DESCRIPTION
The Gruntfile is just a dev dep of this project - it makes no sense to have it as a `main`. Conversely, setting `lib/generate-message.js` to be `main` allows someone to re-use this task's business logic via `require('grunt-attention')`.
